### PR TITLE
Create an entrypoint with a socket server, which runs kedro pipelines on demand [Closes #11]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,4 +20,5 @@ RUN chmod -R a+w /home/kedro
 
 EXPOSE 8888
 
-CMD ["kedro", "run"]
+#CMD ["kedro", "run"]
+CMD ["python", "entrypoint.py"]

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -5,12 +5,26 @@ socket commands to start kedro pipelines
 import asyncio
 import logging
 
+logging.basicConfig(
+    level=logging.DEBUG,
+    style="{",
+    format="{levelname} - {asctime} - {module} - {message}",
+)
 logger = logging.getLogger(__name__)
 
+
+# Map command to subprocess to run
+# TODO: check how to run kedro programmatically instead of
+# running it as a subprocess
 CMD_TO_ACTION_MAP_SUBPROCESS = {"RUN_PIPELINE": "kedro run"}
 
 
 async def run(cmd):
+    """
+    Coroutine which runs a subprocess on the system
+
+    https://docs.python.org/3/library/asyncio-subprocess.html
+    """
     proc = await asyncio.create_subprocess_shell(
         cmd, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE
     )
@@ -19,20 +33,26 @@ async def run(cmd):
 
     print(f"[{cmd!r} exited with {proc.returncode}]")
     if stdout:
-        print(f"[stdout]\n{stdout.decode()}")
+        logger.info(f"[stdout]\n{stdout.decode()}")
     if stderr:
-        print(f"[stderr]\n{stderr.decode()}")
+        logger.error(f"[stderr]\n{stderr.decode()}")
 
 
-# Based on https://docs.python.org/3/library/asyncio-stream.html#tcp-echo-server-using-streams
-async def handle_echo(reader, writer):
+async def handle_client(reader, writer):
+    """
+    Coroutine which handles I/O for clients connected to socket server
+
+    https://docs.python.org/3/library/asyncio-stream.html#tcp-echo-server-using-streams
+    """
     command = None
+
+    # TODO: check message received
     while command != "QUIT":
         data = await reader.read(100)
         command = data.decode().strip()
         addr = writer.get_extra_info("peername")
 
-        print(f"Received {command!r} from {addr!r}")
+        logger.info(f"Received {command!r} from {addr!r}")
 
         # Check if requested action exists
         if command in CMD_TO_ACTION_MAP_SUBPROCESS:
@@ -45,15 +65,15 @@ async def handle_echo(reader, writer):
             writer.write(f"Requested action {command!r} not found\n".encode())
             await writer.drain()
 
-    print("Closed the connection")
+    logger.info("Closed the connection")
     writer.close()
 
 
 async def main():
-    server = await asyncio.start_server(handle_echo, "127.0.0.1", 8888)
+    server = await asyncio.start_server(handle_client, "127.0.0.1", 8888)
 
     addrs = ", ".join(str(sock.getsockname()) for sock in server.sockets)
-    print(f"Serving on {addrs}")
+    logger.info(f"Serving on {addrs}")
 
     async with server:
         await server.serve_forever()

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -1,0 +1,63 @@
+"""
+Entrypoint script which runs eternally, waiting for 
+socket commands to start kedro pipelines
+"""
+import asyncio
+import logging
+
+logger = logging.getLogger(__name__)
+
+CMD_TO_ACTION_MAP_SUBPROCESS = {"RUN_PIPELINE": "kedro run"}
+
+
+async def run(cmd):
+    proc = await asyncio.create_subprocess_shell(
+        cmd, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE
+    )
+
+    stdout, stderr = await proc.communicate()
+
+    print(f"[{cmd!r} exited with {proc.returncode}]")
+    if stdout:
+        print(f"[stdout]\n{stdout.decode()}")
+    if stderr:
+        print(f"[stderr]\n{stderr.decode()}")
+
+
+# Based on https://docs.python.org/3/library/asyncio-stream.html#tcp-echo-server-using-streams
+async def handle_echo(reader, writer):
+    command = None
+    while command != "QUIT":
+        data = await reader.read(100)
+        command = data.decode().strip()
+        addr = writer.get_extra_info("peername")
+
+        print(f"Received {command!r} from {addr!r}")
+
+        # Check if requested action exists
+        if command in CMD_TO_ACTION_MAP_SUBPROCESS:
+            writer.write(
+                f"Requested action {command!r} : {CMD_TO_ACTION_MAP_SUBPROCESS[command]}\n".encode()
+            )
+            await writer.drain()
+            await run(CMD_TO_ACTION_MAP_SUBPROCESS[command])
+        else:
+            writer.write(f"Requested action {command!r} not found\n".encode())
+            await writer.drain()
+
+    print("Closed the connection")
+    writer.close()
+
+
+async def main():
+    server = await asyncio.start_server(handle_echo, "127.0.0.1", 8888)
+
+    addrs = ", ".join(str(sock.getsockname()) for sock in server.sockets)
+    print(f"Serving on {addrs}")
+
+    async with server:
+        await server.serve_forever()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/test_client.py
+++ b/test_client.py
@@ -1,0 +1,40 @@
+"""
+Test client for the socket server responsible
+for launching kedro pipelines
+"""
+
+import asyncio
+import logging
+
+# TODO: DRY
+CMD_TO_ACTION_MAP_SUBPROCESS = {"RUN_PIPELINE": "kedro run"}
+
+logging.basicConfig(
+    level=logging.DEBUG,
+    style="{",
+    format="{levelname} - {asctime} - {module} - {message}",
+)
+logger = logging.getLogger(__name__)
+ADDRESS = "127.0.0.1"
+PORT = 8888
+
+
+async def tcp_echo_client(message):
+    reader, writer = await asyncio.open_connection(ADDRESS, PORT)
+
+    logger.info(f"Send: {message!r}")
+    writer.write(message.encode())
+
+    data = await reader.read(100)
+    logger.debug(f"Received: {data.decode()!r}")
+
+    logger.info("Close the connection")
+    writer.close()
+
+
+if __name__ == "__main__":
+    command = None
+    while command != "quit":
+        command = input("Input command to execute: ")
+        if command in CMD_TO_ACTION_MAP_SUBPROCESS:
+            asyncio.run(tcp_echo_client(command))


### PR DESCRIPTION
Created a simple python script which starts an asyncio socket server on port 8888.

Once a client is connected (either by `telnet localhost 8888` or by `python test_client.py`) they can send any of the available commands (currently: "QUIT" and "RUN_PIPELINE") as plain text. 

"RUN_PIPELINE" will execute `kedro run` as a subprocess. 

This is inteded to be a prototype for testing purposes. 

Ideally, kedro should maybe be run programmatically.  

-----

Once deployed, by opening a terminal on the pod running the code, one can start the `test_client.py` script and type `RUN_PIPELINE` in the prompt. The kedro pipeline should be triggered